### PR TITLE
Use logic simulation mode of vivado

### DIFF
--- a/flows/vivado/impl.tcl
+++ b/flows/vivado/impl.tcl
@@ -11,7 +11,7 @@ read_verilog $netlist
 # Open (link) the design — must be after reading Verilog
 link_design -part $part -top $top
 
-write_verilog  -force -mode design $synth_file
+write_verilog  -force -mode funcsim $synth_file
 
 # Now you can do P&R
 opt_design
@@ -19,7 +19,7 @@ place_design
 route_design
 
 # Export outputs
-write_verilog -force -mode design $impl_file
+write_verilog -force -mode funcsim $impl_file
 # write_sdf     -force              netlist/post_impl.sdf
 # write_xdc     -no_fixed_only -exclude_timing -add_netlist_placement \
 #                -force netlist/impl_placement.xdc

--- a/flows/yosys/miter_check.ys.in
+++ b/flows/yosys/miter_check.ys.in
@@ -1,23 +1,22 @@
-read_verilog __RTL__
+read_verilog -DGLBL __RTL__
 rename __TOP__ netlist
 
-read_verilog __PNR__
+read_verilog -DGLBL __PNR__
 rename __TOP__ impl
 
 read_verilog __PRIMS__
 
-proc; memory; opt
-
 miter -equiv -make_assert netlist impl eq_top
-show      -format dot -prefix __OUT__/miter_raw
 
-hierarchy -top eq_top; proc; flatten;
-opt_clean; proc; memory; opt
+hierarchy -top eq_top; flatten;
+proc;
 
 show      -format dot -prefix __OUT__/miter_flat
 
 write_json -noscopeinfo -selected __OUT__/eq_top.json
 write_verilog -noattr __OUT__/eq_top.v
-sat -dump_vcd __OUT__/counter_example.vcd -verify-no-timeout -timeout 1 -prove-asserts -tempinduct eq_top
+
 dffunmap
+
+sat -dump_vcd __OUT__/counter_example.vcd -verify-no-timeout -timeout 1 -prove-asserts -tempinduct eq_top
 write_smt2 __OUT__/eq_top.smt2

--- a/flows/yosys/struct_check.ys.in
+++ b/flows/yosys/struct_check.ys.in
@@ -1,19 +1,18 @@
 read_verilog -lib __PRIMS__
 
-read_verilog  __RTL__
+read_verilog -DGLBL __RTL__
 rename __TOP__ gold
 show -format dot -prefix __OUT__/synth
 
-read_verilog  __PNR__
+read_verilog -DGLBL __PNR__
 rename __TOP__ gate
 show -format dot -prefix __OUT__/impl
 
-equiv_make gold gate equiv_top
+equiv_make gold gate equiv_top;
 
-opt; opt_clean
+proc;
 
-show -format dot -prefix __OUT__/struct
-write_verilog -noattr   __OUT__/equiv_top.v
+show -format dot -prefix __OUT__/struct_equiv
 
 equiv_struct             equiv_top
 equiv_status   -assert   equiv_top

--- a/scripts/fuzzer.sh
+++ b/scripts/fuzzer.sh
@@ -24,7 +24,7 @@ PERMANENT_LOGS=${PERMANENT_LOGS:-"logs"}
 
 LIBRARY=${LIBRARY:-hardware/cells/xilinx.yaml}
 CONFIG=${CONFIG:-config/settings.toml}
-PRIMS=${PRIMS:-"+/xilinx/cells_map.v +/xilinx/cells_sim.v"}
+PRIMS=${PRIMS:-"+/xilinx/cells_sim.v"}
 
 XILINX_TCL=${XILINX_TCL:-flows/vivado/impl.tcl}
 VIVADO_BIN=${VIVADO_BIN:-"/opt/Xilinx/Vivado/2024.2/bin/vivado"}


### PR DESCRIPTION
This pull request includes changes to improve simulation accuracy, streamline equivalence checking flows, and update library configurations. The most important changes involve modifying Verilog modes in Vivado implementation scripts, adding global definitions in Yosys scripts, and refining equivalence checking processes.

### Simulation Accuracy Improvements:
* [`flows/vivado/impl.tcl`](diffhunk://#diff-9bc5b6e240052c7dae768e4f3f5d8e0c141939ef8161f4ebab41737e1d7711eaL14-R22): Changed the Verilog output mode from `design` to `funcsim` for both synthesis and implementation stages to ensure functional simulation accuracy.

### Equivalence Checking Enhancements:
* [`flows/yosys/miter_check.ys.in`](diffhunk://#diff-882820afe3b8b90e97d764d544eeebacf629d27c2f0f658c35c8a58779cdcdb4L1-R21): Added `-DGLBL` to `read_verilog` commands to include global definitions, reordered commands for better flow, and adjusted the SAT solver invocation for improved verification.
* [`flows/yosys/struct_check.ys.in`](diffhunk://#diff-7c93c0adfbddb7ee4ac7f847a2ca3357b40158475727002097e0b3b05eb12c42L3-R15): Added `-DGLBL` to `read_verilog` commands, replaced optimization steps with `proc` for consistency, and updated the output file naming convention for structural equivalence checks.

### Library Configuration Update:
* [`scripts/fuzzer.sh`](diffhunk://#diff-15ce390f95729d3cc09b21b90dc9fe928965ffc7d38b705d35450b193d551e51L27-R27): Removed `cells_map.v` from the `PRIMS` variable, leaving only `cells_sim.v`, to streamline the library configuration for simulation purposes.

Closes #27 